### PR TITLE
fix: DashBoard 단어팩 교체 버튼 디자인 수정, myword/incorrectword에서 표가 div범위를 넘어가는 부분 수정

### DIFF
--- a/src/pages/DashBoard.jsx
+++ b/src/pages/DashBoard.jsx
@@ -147,25 +147,51 @@ const DashBoard = ({
 
       {/* 진행중인 단어팩 카드 */}
       <div className="bg-white rounded-2xl shadow-lg p-6 mb-8 border border-gray-100">
-        <div className="flex items-center justify-between">
+        {/* --- 넓은 화면용 레이아웃 (sm 사이즈 이상에서만 보임) --- */}
+        <div className="hidden sm:flex items-center justify-between">
+          {/* 좌측 (아이콘 + 텍스트) */}
           <div className="flex items-center space-x-3">
-            <div className="w-12 h-12 bg-gradient-to-r from-blue-500 to-purple-500 rounded-xl flex items-center justify-center">
+            <div className="w-12 h-12 bg-gradient-to-r from-blue-500 to-purple-500 rounded-xl flex items-center justify-center flex-shrink-0">
               <span className="text-white text-xl">📚</span>
             </div>
             <div>
-              <h3 className="text-lg font-semibold text-gray-800">
+              <h3 className="text-lg font-semibold text-gray-800 break-keep">
                 진행중인 단어팩
               </h3>
-              <p className="text-gray-600">
+              <p className="text-gray-600 break-keep">
                 {currentProgress?.name || "선택되지 않음"}
               </p>
             </div>
           </div>
+
+          {/* 우측 (기존 버튼) */}
           <button
-            className="bg-gradient-to-r from-blue-500 to-purple-500 text-white px-6 py-3 rounded-xl hover:from-blue-600 hover:to-purple-600 transition-all duration-300 shadow-md hover:shadow-lg transform  "
+            className="bg-gradient-to-r from-blue-500 to-purple-500 text-white px-6 py-3 rounded-xl hover:from-blue-600 hover:to-purple-600 transition-all duration-300 shadow-md hover:shadow-lg transform whitespace-nowrap"
             onClick={handleGoWordPackChoice}
           >
             변경하기
+          </button>
+        </div>
+
+        {/* --- 좁은 화면용 레이아웃 (sm 사이즈 미만에서만 보임) --- */}
+        <div className="block sm:hidden">
+          {/* 상단 (텍스트만) */}
+          <div>
+            <h3 className="text-lg font-semibold text-gray-800 break-keep">
+              진행중인 단어팩
+            </h3>
+            <p className="text-gray-600 break-keep">
+              {currentProgress?.name || "선택되지 않음"}
+            </p>
+          </div>
+
+          {/* 하단 (아이콘 + 텍스트 합쳐진 새 버튼) */}
+          <button
+            className="mt-4 w-full bg-gradient-to-r from-blue-500 to-purple-500 text-white py-3 rounded-xl hover:from-blue-600 hover:to-purple-600 transition-all duration-300 shadow-md hover:shadow-lg flex items-center justify-center space-x-2"
+            onClick={handleGoWordPackChoice}
+          >
+            <span className="text-xl">📚</span>
+            <span>변경하기</span>
           </button>
         </div>
       </div>
@@ -176,7 +202,7 @@ const DashBoard = ({
           <div className="w-10 h-10 bg-gradient-to-r from-green-500 to-emerald-500 rounded-xl flex items-center justify-center">
             <span className="text-white text-lg">📊</span>
           </div>
-          <h2 className="text-2xl font-bold text-gray-800">오늘의 진행상황</h2>
+          <h2 className="text-2xl font-bold text-gray-800 break-keep">오늘의 진행상황</h2>
         </div>
 
         <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
@@ -238,7 +264,7 @@ const DashBoard = ({
           {/* 학습 바로가기 */}
           <div className="flex flex-col justify-center">
             <button
-              className="bg-gradient-to-r from-blue-500 to-purple-500 text-white px-8 py-4 rounded-xl hover:from-blue-600 hover:to-purple-600 transition-all duration-300 shadow-lg hover:shadow-xl transform   text-lg font-semibold"
+              className="bg-gradient-to-r from-blue-500 to-purple-500 text-white px-8 py-4 rounded-xl hover:from-blue-600 hover:to-purple-600 transition-all duration-300 shadow-lg hover:shadow-xl transform text-lg font-semibold whitespace-now" // <-- 이 부분을 추가해주세요
               onClick={handleGoWordStudy}
             >
               🚀 학습 시작하기
@@ -269,7 +295,7 @@ const DashBoard = ({
               <span className="text-2xl">📅</span>
             </div>
             <div className="text-right">
-              <p className="text-green-100 text-sm">오늘의 단어</p>
+              <p className="text-green-100 text-sm whitespace-nowrap">오늘의 단어</p>
               <p className="text-3xl font-bold">{todayWordsCount}</p>
             </div>
           </div>
@@ -282,7 +308,7 @@ const DashBoard = ({
               <span className="text-2xl">❌</span>
             </div>
             <div className="text-right">
-              <p className="text-red-100 text-sm">틀린 단어</p>
+              <p className="text-red-100 text-sm ">틀린 단어</p>
               <p className="text-3xl font-bold">{incorrectWordsCount}</p>
             </div>
           </div>

--- a/src/pages/My/IncorrectWord.jsx
+++ b/src/pages/My/IncorrectWord.jsx
@@ -151,7 +151,7 @@ const IncorrectWord = ({ setActiveSubTab }) => {
           <p className="text-gray-600 text-sm sm:text-base">틀린 단어 모음</p>
         </div>
         <div
-          className={`w-full ${
+          className={`${
             doStudy ? "ml-0 sm:ml-[7%] " : "ml-0 sm:ml-[10%]"
           } max-w-2xl flex justify-end items-end gap-2`}
         >
@@ -201,7 +201,7 @@ const IncorrectWord = ({ setActiveSubTab }) => {
             </div>
           </div>
         ) : (
-          <div className="w-full max-w-2xl bg-white rounded-xl shadow ml-0 sm:ml-[10%]">
+          <div className="max-w-2xl bg-white rounded-xl shadow ml-0 sm:ml-[10%]">
             <div className="bg-gray-100 px-2 sm:px-4 py-3 text-xs sm:text-sm font-semibold text-gray-700 flex justify-between">
               <div className="w-[10%] flex-shrink-0"></div>
               <div className="w-[35%] sm:w-[35%] ml-2 sm:ml-0">단어</div>

--- a/src/pages/My/MyWord.jsx
+++ b/src/pages/My/MyWord.jsx
@@ -123,7 +123,7 @@ const MyWord = ({ setActiveSubTab }) => {
           <p className="text-gray-600 text-sm sm:text-base">내 단어장</p>
         </div>
         <div
-          className={`w-full ${
+          className={` ${
             doStudy ? "" : "ml-0 sm:ml-[10%] max-w-2xl"
           } flex justify-end align-right gap-2`}
         >
@@ -151,7 +151,7 @@ const MyWord = ({ setActiveSubTab }) => {
             page="MyWord"
           />
         ) : (
-          <div className="w-full max-w-2xl bg-white rounded-xl shadow ml-0 sm:ml-[10%]">
+          <div className="max-w-2xl bg-white rounded-xl shadow ml-0 sm:ml-[10%]">
             <div className="bg-gray-100 px-2 sm:px-4 py-3 text-xs sm:text-sm font-semibold text-gray-700 flex justify-between">
               <div className="w-[10%] flex-shrink-0"></div>
               <div className="w-[35%] sm:w-[35%] ml-2 sm:ml-0">단어</div>


### PR DESCRIPTION
DashBoard.jsx 파일에서 화면 비율에 따른 넓은 화면용 레이아웃과 좁은 화면용 레이아웃 두 가지 방식으로 실행되게 수정
MyWord.jsx, IncorrectWord.jsx 파일에서 공통적으로 있던 <div className="w-full max-w-2xl bg-white rounded-xl shadow ml-0 sm:ml-[10%]"> 위 코드에서 w-full를 삭제 내 단어장표와 틀린단어장의 표가 div를 벗어나게 되는 부분 수정